### PR TITLE
hotfix: ping regions twice from client

### DIFF
--- a/src/pages/Latency/index.jsx
+++ b/src/pages/Latency/index.jsx
@@ -91,6 +91,7 @@ async function getClientRegionLatencies(regions, setLatencies) {
 async function getClientRegionLatency(region) {
   console.log(region.code)
   const url = `https://dynamodb.${region.code}.amazonaws.com`
+  await fetch(url)
   const now = performance.now()
   await fetch(url)
   const latency = performance.now() - now


### PR DESCRIPTION
For some reason the first client-to-region requests takes an abnormally long amount of time. Might have something to do with DNS resolution or the like. Making two requests is a quick and dirty way to solve this for now. These requests cost next to nothing so it isn't a big deal. Of course, it would be better to keep track of initial requests and subsequently not ping twice.